### PR TITLE
Use /usr/bin/env bash for shebang

### DIFF
--- a/run-claude.sh
+++ b/run-claude.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Claude Code Docker Runner Script
 # Usage: ./run-claude.sh [options] [command]


### PR DESCRIPTION
This PR improves script portability by using `/usr/bin/env bash` instead of `#!/bin/bash`.

## Benefits

- Allows users to use their preferred bash version from `$PATH`
- Particularly beneficial on macOS where `/bin/bash` is stuck at version 3.2.57 (from 2007)
- Homebrew and other package managers provide much newer bash versions (5.3+)
- Follows bash scripting best practices for portability

## Changes

- Changed shebang from `#!/bin/bash` to `#!/usr/bin/env bash`

Fixes #3