### PR TITLE
🐛 fix: Reject conflicting --pull and --rebuild flags

### DIFF
--- a/run-claude.sh
+++ b/run-claude.sh
@@ -619,6 +619,12 @@ if [[ "$FORCE_PULL" == "true" && "$BUILD_ONLY" == "true" ]]; then
   exit 1
 fi
 
+if [[ "$FORCE_PULL" == "true" && "$FORCE_REBUILD" == "true" ]]; then
+  echo -e "${RED}Error: Cannot use --pull and --rebuild together${NC}"
+  echo -e "${YELLOW}Choose one: --pull (to pull latest image) or --rebuild (to force local rebuild)${NC}"
+  exit 1
+fi
+
 # Validate that --extra-package is only used with appropriate commands
 if [[ ${#EXTRA_PACKAGES[@]} -gt 0 ]]; then
   if [[ "$BUILD_ONLY" != "true" && "$FORCE_REBUILD" != "true" && -z "$EXPORT_DOCKERFILE" ]]; then


### PR DESCRIPTION
Previously, passing both --pull and --rebuild caused --rebuild to be silently discarded due to the if/elif ordering in the image preparation block. The user's local rebuild intent (and any --extra-package additions) were lost without warning.

Add a validation check parallel to the existing --pull/--build guard so the conflict is rejected at startup with a clear error message.

Fixes: #7